### PR TITLE
`npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Your Mom
 A golfing language
 
-Just run `npm install && npm run build` to build
+Just run `npm install` to install and compile. Then run `npm start` or `node ./lib/yourmom.js` to run.
 
-`npm run build` visibly don't work on some machines. If this happen to you, run directly `src/yourmom.js`
+If `npm install` errors. Run `rm -rf node_modules/ && npm install`.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublish": "./node_modules/.bin/babel src -d lib --minified",
+    "start": "node ./lib/yourmom.js",
     "build": "./node_modules/.bin/babel src -d lib"
   },
   "repository": {


### PR DESCRIPTION
No need to do `npm run build` as I've integrated it with `npm install`. I also added `npm start` to run yourmom. I've updated the README to detail this information too